### PR TITLE
fix: try to fix cross-compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ Get os native machine id without root permission.
 [target.'cfg(windows)'.dependencies]
 winreg = "0.11"
 
-[target.'cfg(windows)'.build-dependencies]
+# [target.'cfg(windows)'.build-dependencies]
+[build-dependencies]
 cc = "1.0"
 bindgen = "0.59"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,12 @@
+use std::env;
 fn main() {
-    #[cfg(target_os = "windows")]
-    {
+    let target_os = env::var("CARGO_CFG_TARGET_OS");
+    if target_os.is_ok() && target_os.unwrap() == "windows" {
         use cc::Build;
-        println!("cargo:rustc-link-lib=Kernel32");
-        Build::new().file("src/win.cpp").compile("machine-uid");
+        // println!("cargo:rustc-link-lib=Kernel.a");
+        Build::new()
+            .file("src/win.cpp")
+            .cpp_link_stdlib("stdc++")
+            .compile("machine-uid");
     }
 }


### PR DESCRIPTION
Close: #6 

- `target_os` should not be used in `build.rs`. See https://users.rust-lang.org/t/cross-compiling-os-x-to-linux/18883/4
- `cargo:rustc-link-lib=Kernel32` is not necessary (maybe)